### PR TITLE
Changing the export macro.

### DIFF
--- a/ParaViewCore/VTKExtensions/vtkMultiBlockTemporalStatistics.h
+++ b/ParaViewCore/VTKExtensions/vtkMultiBlockTemporalStatistics.h
@@ -69,7 +69,7 @@ class vtkInformationObjectBaseKey;
 class vtkMultiProcessController;
 class vtkMultiBlockTemporalStatisticsInternal;
 
-class VTK_GRAPHICS_EXPORT vtkMultiBlockTemporalStatistics : public vtkMultiBlockDataSetAlgorithm
+class VTK_EXPORT vtkMultiBlockTemporalStatistics : public vtkMultiBlockDataSetAlgorithm
 {
 public:
   vtkTypeMacro(vtkMultiBlockTemporalStatistics, vtkMultiBlockDataSetAlgorithm);


### PR DESCRIPTION
Fixes the export to VTK_EXPORT. Not a major change but done for consistency.
