### PR TITLE
Disabling progress as it is causing issues with STP stuff.

### DIFF
--- a/ParaViewCore/ClientServerCore/vtkPVProgressHandler.cxx
+++ b/ParaViewCore/ClientServerCore/vtkPVProgressHandler.cxx
@@ -43,7 +43,7 @@
 
 // define this variable to disable progress all together. This may be useful to
 // doing really large runs.
-// #define PV_DISABLE_PROGRESS_HANDLING
+#define PV_DISABLE_PROGRESS_HANDLING
 
 inline const char* vtkGetProgressText(vtkObjectBase* o)
 {


### PR DESCRIPTION
The vtkPVProgressHandler is calling vtkMultiProcessController::GetGlobalController()
at rather arbitrary times and is not getting a consistent global
controller with the vtkMultiBlockSpatioTemporalStatistics filter
as that filter plays around with the global controller. This is
causing memory access issues so I'm disabling progress.
